### PR TITLE
Ansible play_hosts variables is deprecated since 2.2 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # cluster config
-postgres_ha_cluster_master_host: "{{ play_hosts[0] }}"     # sync all DB slaves from this master node (set to first node if not defined)
+postgres_ha_cluster_master_host: "{{ ansible_play_batch[0] }}"     # sync all DB slaves from this master node (set to first node if not defined)
 postgres_ha_cluster_name: 'pgcluster'                      # name of the pcs cluster
 postgres_ha_cluster_vip:  10.20.30.40                      # floating IP that will be used to connect to clustered DB (always follows the master)
 postgres_ha_cluster_vip_mask: 24                           # floating IP netmask
@@ -23,8 +23,8 @@ postgres_ha_pg_bindir: "/usr/pgsql-{{ postgres_ha_pg_version }}/bin"        # wh
 
 postgres_ha_postgresql_conf_vars:                          # When altering this variable, please copy all postgresql.conf items specified here \
     listen_addresses: "'*'"                                     # because this whole variable will be overloaded by your new definition. \
-    max_wal_senders: "{{ play_hosts|length * 2 }}"              # You can change also other postgresql.conf variables here, it will work.
-    max_replication_slots: "{{ play_hosts|length * 2 }}"
+    max_wal_senders: "{{ ansible_play_batch|length * 2 }}"              # You can change also other postgresql.conf variables here, it will work.
+    max_replication_slots: "{{ ansible_play_batch|length * 2 }}"
     wal_level: "hot_standby"
     hot_standby: "on"
     wal_log_hints: "on"

--- a/tasks/constraints.yml
+++ b/tasks/constraints.yml
@@ -2,11 +2,11 @@
 
 # location constraints
 - name: setting VIP location constraints
-  shell: pcs constraint location "{{ postgres_ha_cluster_vip_res_name }}" prefers {% for clhost in play_hosts %}{{clhost}}=100 {% endfor %}
+  shell: pcs constraint location "{{ postgres_ha_cluster_vip_res_name }}" prefers {% for clhost in ansible_play_batch %}{{clhost}}=100 {% endfor %}
   when: inventory_hostname == "{{ postgres_ha_cluster_master_host }}"   # run only on one node
 
 - name: setting DB location constraints
-  shell: pcs constraint location "{{ postgres_ha_cluster_pg_HA_res_name }}" prefers {% for clhost in play_hosts %}{{clhost}}=100 {% endfor %}
+  shell: pcs constraint location "{{ postgres_ha_cluster_pg_HA_res_name }}" prefers {% for clhost in ansible_play_batch %}{{clhost}}=100 {% endfor %}
   when: inventory_hostname == "{{ postgres_ha_cluster_master_host }}"   # run only on one node
 
 

--- a/tasks/finalize.yml
+++ b/tasks/finalize.yml
@@ -16,7 +16,7 @@
   register: slavecount
   vars:
     ansible_ssh_pipelining: no
-  until: (slavecount.stdout|string) == ((play_hosts|length - 1)|string)
+  until: (slavecount.stdout|string) == ((ansible_play_batch|length - 1)|string)
   retries: 16
   delay: 2
 

--- a/tasks/paf.yml
+++ b/tasks/paf.yml
@@ -73,7 +73,7 @@
     options:
       master-max      : 1
       master-node-max : 1
-      clone-max       : "{{ play_hosts|length }}"
+      clone-max       : "{{ ansible_play_batch|length }}"
       clone-node-max  : 1
       notify          : true
 

--- a/tasks/pcs.yml
+++ b/tasks/pcs.yml
@@ -1,12 +1,12 @@
 # vim: set filetype=yaml expandtab tabstop=2 shiftwidth=2 softtabstop=2 background=dark :
 
-- debug: msg='cluster_members={{play_hosts}}'
+- debug: msg='cluster_members={{ansible_play_batch}}'
   run_once: true
 
 - name: "Build hosts file"
   lineinfile: dest=/etc/hosts regexp='.*{{ item }}$' line="{{ hostvars[item].ansible_default_ipv4.address }} {{ item }}" state=present
   when: hostvars[item].ansible_default_ipv4.address is defined
-  with_items: "{{play_hosts}}"
+  with_items: "{{ansible_play_batch}}"
 
 - name: install cluster pkgs
   yum:
@@ -24,10 +24,10 @@
     password: "{{ postgres_ha_cluster_ha_password_hash }}"
 
 - name: setup cluster auth
-  shell: pcs cluster auth {{ play_hosts | join( " ") }} -u hacluster -p "{{ postgres_ha_cluster_ha_password }}"
+  shell: pcs cluster auth {{ ansible_play_batch | join( " ") }} -u hacluster -p "{{ postgres_ha_cluster_ha_password }}"
 
 - name: create cluster
-  #shell: pcs cluster setup --name {{ postgres_ha_cluster_name }} {{ play_hosts | join( " ") }}
+  #shell: pcs cluster setup --name {{ postgres_ha_cluster_name }} {{ ansible_play_batch | join( " ") }}
   shell: pcs cluster setup --name {{ postgres_ha_cluster_name }} "{{ postgres_ha_cluster_master_host }}"
   when: inventory_hostname == "{{ postgres_ha_cluster_master_host }}"   # run only on one node
   args:
@@ -36,7 +36,7 @@
 - name: join cluster nodes
   shell: /bin/sh -c "if ! grep -q 'ring0_addr[:] *{{ item }}[\t ]*$' /etc/corosync/corosync.conf; then pcs cluster node add {{ item }}; fi"
   when: inventory_hostname == "{{ postgres_ha_cluster_master_host }}"             # run only on one node
-  with_items: '{{ play_hosts | difference([inventory_hostname]) }}'   # all hosts except me
+  with_items: '{{ ansible_play_batch | difference([inventory_hostname]) }}'   # all hosts except me
   register: join_cluster
 
 #- name: alter votequorum config

--- a/tasks/postgresql_sync.yml
+++ b/tasks/postgresql_sync.yml
@@ -45,7 +45,7 @@
     regexp='^host    postgres .*{{ hostvars[item].ansible_default_ipv4.address }}/32'
     insertbefore='^host'
     line='host    postgres       {{ postgres_ha_pg_repl_user }}    {{ hostvars[item].ansible_default_ipv4.address }}/32          md5'
-  with_items: "{{ play_hosts }}"
+  with_items: "{{ ansible_play_batch }}"
   when: inventory_hostname == "{{ postgres_ha_cluster_master_host }}" or
         db_prevsync_file.stat.exists
         # run only on master node or on synchronized slave
@@ -56,7 +56,7 @@
     regexp='^host    replication .*{{ hostvars[item].ansible_default_ipv4.address }}/32'
     insertbefore='^host'
     line='host    replication     {{ postgres_ha_pg_repl_user }}    {{ hostvars[item].ansible_default_ipv4.address }}/32          md5'
-  with_items: "{{ play_hosts }}"
+  with_items: "{{ ansible_play_batch }}"
   when: inventory_hostname == "{{ postgres_ha_cluster_master_host }}" or
         db_prevsync_file.stat.exists
         # run only on master node or on synchronized slave
@@ -83,7 +83,7 @@
 
 - name: setup .pgpass replication auth for other IPs
   lineinfile: dest="~postgres/.pgpass" line="{{ hostvars[item].ansible_default_ipv4.address }}:{{ postgres_ha_pg_port }}:replication:{{ postgres_ha_pg_repl_user }}:{{ postgres_ha_pg_repl_pass }}" state=present
-  with_items: "{{play_hosts}}"
+  with_items: "{{ansible_play_batch}}"
   args:
     owner: postgres
     group: postgres
@@ -215,6 +215,6 @@
   register: slavecount
   vars:
     ansible_ssh_pipelining: no
-  until: (slavecount.stdout|string) == ((play_hosts|length - 1)|string)
+  until: (slavecount.stdout|string) == ((ansible_play_batch|length - 1)|string)
   retries: 15
   delay: 2

--- a/tasks/pre-tasks.yml
+++ b/tasks/pre-tasks.yml
@@ -4,6 +4,6 @@
 
 - name: verify postgres_ha_cluster_master_host
   fail:
-    msg: "CRITICAL: defined master host ({{ postgres_ha_cluster_master_host }}) is not in host list ({{ play_hosts }})"
-  when: postgres_ha_cluster_master_host not in play_hosts
+    msg: "CRITICAL: defined master host ({{ postgres_ha_cluster_master_host }}) is not in host list ({{ ansible_play_batch }})"
+  when: postgres_ha_cluster_master_host not in ansible_play_batch
 

--- a/templates/pg_hba.conf.j2
+++ b/templates/pg_hba.conf.j2
@@ -6,7 +6,7 @@ local  all  postgres    trust
 # "local" is for Unix domain socket connections only
 local  all  all    md5
 # replication ACLs
-{% for node in play_hosts %}
+{% for node in ansible_play_batch %}
 host  replication  {{ postgres_ha_pg_repl_user }}  {{ hostvars[node].ansible_default_ipv4.address }}/32  md5
 host  postgres     {{ postgres_ha_pg_repl_user }}  {{ hostvars[node].ansible_default_ipv4.address }}/32  md5
 {% endfor %}


### PR DESCRIPTION
Ansible play_hosts variables is deprecated since 2.2 replaced by ansible_play_batch : 
http://docs.ansible.com/ansible/latest/playbooks_variables.html#magic-variables-and-how-to-access-information-about-other-hosts